### PR TITLE
Add GNOME 43 to metadata

### DIFF
--- a/expandable-notifications@kaan.g.inam.org/metadata.json
+++ b/expandable-notifications@kaan.g.inam.org/metadata.json
@@ -7,6 +7,6 @@
   "gettext-domain": "expandable-notifications",
   "url": "https://github.com/kaanginam/expandable-notifications",
   "shell-version": [
-    "40", "41", "42"
+    "40", "41", "42", "43"
   ]
 }


### PR DESCRIPTION
Since everything seems to work on GNOME 43, I would suggest to add it to the supported versions.