### PR TITLE
Add Gnome44 support

### DIFF
--- a/expandable-notifications@kaan.g.inam.org/metadata.json
+++ b/expandable-notifications@kaan.g.inam.org/metadata.json
@@ -7,6 +7,6 @@
   "gettext-domain": "expandable-notifications",
   "url": "https://github.com/kaanginam/expandable-notifications",
   "shell-version": [
-    "40", "41", "42", "43"
+    "40", "41", "42", "43", "44"
   ]
 }


### PR DESCRIPTION
It worked in Gnome 44(might?)
At least the expand button works without crashing.